### PR TITLE
GH-59: Fix the last frame generation issue

### DIFF
--- a/src/thumbnails/__init__.py
+++ b/src/thumbnails/__init__.py
@@ -22,7 +22,7 @@ from .thumbnail import ThumbnailJSON
 from .thumbnail import ThumbnailVTT
 from .thumbnail import register_thumbnail
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 __all__ = (
     "Generator",
     "Thumbnail",


### PR DESCRIPTION
This fixes the `cannot identify image file` issue. The previously occurring issue had other causes. This happens when FFmpeg cannot extract the last frame in the range of duration parsed by itself.

Issue:
 - #59 