### PR TITLE
Fix PyAV version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest ]
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,7 @@ classifiers =
 packages =
     thumbnails
 install_requires =
-    av==8.0.0;sys_platform=='win32'
-    av>=11.0.0;sys_platform!='win32'
+    av>=11.0.0
     click>=8.0.3
     imageio-ffmpeg>=0.4.7
     imageio>=2.23.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     imageio>=2.23.0
     pillow>=8.4.0
     rich==13.0.0
-python_requires = >=3.7
+python_requires = >=3.8
 package_dir =
     =src
 zip_safe = no

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,12 +38,12 @@ packages =
     thumbnails
 install_requires =
     av==8.0.0;sys_platform=='win32'
-    av==9.2.0;sys_platform!='win32'
+    av>=11.0.0;sys_platform!='win32'
     click>=8.0.3
     imageio-ffmpeg>=0.4.7
     imageio>=2.23.0
     pillow>=8.4.0
-    rich>=13.0.0
+    rich==13.0.0
 python_requires = >=3.7
 package_dir =
     =src

--- a/src/thumbnails/__init__.py
+++ b/src/thumbnails/__init__.py
@@ -22,7 +22,7 @@ from .thumbnail import ThumbnailJSON
 from .thumbnail import ThumbnailVTT
 from .thumbnail import register_thumbnail
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"
 __all__ = (
     "Generator",
     "Thumbnail",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-minversion = 3.7.0
+minversion = 3.8.0
 envlist =
-    python3.7
     python3.8
     python3.9
+    python3.10
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
### Motivation:

In the scope of investigating the #69 issue reported by @mahdiar, it turned out that old versions of the `PyAV` package are failing with the latest pip and Python versions. Also, the latest `PyAV` version is compatible with all operating systems supported by this library.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
